### PR TITLE
Move bulkupdate URLs to stanford subdirectory

### DIFF
--- a/cms/djangoapps/contentstore/views/__init__.py
+++ b/cms/djangoapps/contentstore/views/__init__.py
@@ -8,7 +8,6 @@ from .assets import *
 from .utility import *
 from .utilities.captions import *
 from .utilities.bulksettings import *
-from openedx.stanford.cms.djangoapps.contentstore.views.utilities.bulkupdate import *
 from .component import *
 from .course import *
 from .entrance_exam import *

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -83,7 +83,6 @@ urlpatterns += patterns(
         r'^course_info_update/{}/(?P<provided_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
         'course_info_update_handler'
     ),
-    url(r'^utility/bulkupdate/{}$'.format(settings.COURSE_KEY_PATTERN), 'utility_bulkupdate_handler'),
     url(r'^home/?$', 'course_listing', name='home'),
     url(
         r'^course/{}/search_reindex?$'.format(settings.COURSE_KEY_PATTERN),

--- a/openedx/stanford/cms/djangoapps/contentstore/views/utilities/bulkupdate.py
+++ b/openedx/stanford/cms/djangoapps/contentstore/views/utilities/bulkupdate.py
@@ -4,6 +4,7 @@ Views related to bulk update operations on course problems
 
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseNotFound
 
 from edxmako.shortcuts import render_to_response
@@ -43,9 +44,11 @@ def _utility_bulkupdate_get_handler(course_key_string):
         "course_handler",
         course_key_string
     )
-    bulkupdate_url = reverse_course_url(
-        "utility_bulkupdate_handler",
-        course_key_string
+    bulkupdate_url = reverse(
+        'utility_bulkupdate_handler',
+        kwargs={
+            'course_key_string': course_key_string,
+        },
     )
 
     course_key = CourseKey.from_string(course_key_string)

--- a/openedx/stanford/cms/urls.py
+++ b/openedx/stanford/cms/urls.py
@@ -20,6 +20,13 @@ urlpatterns = [
         r'^utility/bulksettings/{}$'.format(settings.COURSE_KEY_PATTERN),
         'contentstore.views.utility_bulksettings_handler',
     ),
+    url(
+        r'^utility/bulkupdate/{}$'.format(
+            settings.COURSE_KEY_PATTERN,
+        ),
+        'openedx.stanford.cms.djangoapps.contentstore.views.utilities.bulkupdate.utility_bulkupdate_handler',
+        name='utility_bulkupdate_handler',
+    ),
 ]
 if settings.SHIB_ONLY_SITE:
     urlpatterns += [


### PR DESCRIPTION
@tanyaxp This should enable us to remove the fork on:
- `cms/djangoapps/contentstore/views/__init__.py`
- `cms/urls.py`